### PR TITLE
0.17 compatibility and correct count on curved rail

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -53,17 +53,14 @@ local function item_from_ghost(ghost)
   -- so we just go with the first. I'm curious where this might be the wrong
   -- thing to do, and how I could fix it.
   local items = ghost.ghost_prototype.items_to_place_this
-  -- luacheck: ignore 512
-  for name, _ in pairs(items) do
-    return name
-  end
+  return items[1]["name"], items[1]["count"]
 end
 
 local function build_signals(ghosts)
   local signals = {}
   for _, ghost in pairs(ghosts) do
     local existing = nil
-    local name = item_from_ghost(ghost)
+    local name, count= item_from_ghost(ghost)
     for _, s in pairs(signals) do
       if s.signal.name == name then existing = s end
     end
@@ -71,7 +68,7 @@ local function build_signals(ghosts)
       existing = { signal = { type = "item", name = name }, count = 0, index = (#signals+1) }
       table.insert(signals, existing)
     end
-    existing.count = existing.count + 1
+    existing.count = existing.count + count
   end
   return signals
 end

--- a/info.json
+++ b/info.json
@@ -1,8 +1,8 @@
 {
   "name": "ConstructionSignaler",
-  "version": "0.16.2",
+  "version": "0.16.5",
   "title": "Construction Signaler",
   "author": "codekitchen",
-  "factorio_version": "0.16",
-  "dependencies": ["base >= 0.16.0"]
+  "factorio_version": "0.17",
+  "dependencies": ["base >= 0.17.0"]
 }


### PR DESCRIPTION
This commit will add compatibility to Factorio 0.17.
Additional it is adding the correct count for items like curved
rails which needs more than one item to construct the ghost

I have not touched the change log as there are two versions missing from GitHub, maybe you want to push them before merging